### PR TITLE
Fix unlimited mode env check

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,10 @@ Each module uses GPT-4o for intelligent data extraction, but follows determinist
 When you clone and run this repository locally, Fire Enrich automatically enables **Unlimited Mode**, removing the restrictions of the public demo. You can configure these limits in [`app/fire-enrich/config.ts`](app/fire-enrich/config.ts):
 
 ```typescript
-const isUnlimitedMode = process.env.FIRE_ENRICH_UNLIMITED === 'true' || 
-                       process.env.NODE_ENV === 'development';
+const isUnlimitedMode =
+  process.env.FIRE_ENRICH_UNLIMITED === 'true' ||
+  process.env.NEXT_PUBLIC_FIRE_ENRICH_UNLIMITED === 'true' ||
+  process.env.NODE_ENV === 'development';
 
 export const FIRE_ENRICH_CONFIG = {
   CSV_LIMITS: {

--- a/app/fire-enrich/config.ts
+++ b/app/fire-enrich/config.ts
@@ -1,6 +1,8 @@
 // Check if running in unlimited mode (when cloned/self-hosted)
-const isUnlimitedMode = process.env.FIRE_ENRICH_UNLIMITED === 'true' || 
-                       process.env.NODE_ENV === 'development';
+const isUnlimitedMode =
+  process.env.FIRE_ENRICH_UNLIMITED === 'true' ||
+  process.env.NEXT_PUBLIC_FIRE_ENRICH_UNLIMITED === 'true' ||
+  process.env.NODE_ENV === 'development';
 
 // Configuration for Fire Enrich
 export const FIRE_ENRICH_CONFIG = {


### PR DESCRIPTION
## Summary
- read `NEXT_PUBLIC_FIRE_ENRICH_UNLIMITED` when checking for unlimited mode
- document the new environment variable in README

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6850f89ed3c8832e8e12d0985d6a95a9