### PR TITLE
Add custom Firecrawl endpoint docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Firecrawl API Key
 # Get yours at https://firecrawl.dev
 FIRECRAWL_API_KEY=fc-your-api-key-here
-
+FIRECRAWL_BASE_URL=https://firecrawl.srv789673.hstgr.cloud
 # OpenAI API Key  
 # Get yours at https://platform.openai.com
 OPENAI_API_KEY=sk-your-api-key-here
@@ -13,3 +13,4 @@ FIRE_ENRICH_UNLIMITED=true
 
 # Node environment (development/production)
 NODE_ENV=development
+

--- a/README.md
+++ b/README.md
@@ -29,11 +29,38 @@ Turn a simple list of emails into a rich dataset with company profiles, funding 
 2. Create a `.env.local` file with your API keys:
    ```
    FIRECRAWL_API_KEY=your_firecrawl_key
+   FIRECRAWL_BASE_URL=https://firecrawl.srv789673.hstgr.cloud
    OPENAI_API_KEY=your_openai_key
    ```
 3. Install dependencies: `npm install` or `yarn install`
 4. Run the development server: `npm run dev` or `yarn dev`
 5. Open [http://localhost:3000](http://localhost:3000)
+
+### Custom Firecrawl Endpoint
+
+If you run a self-hosted Firecrawl instance, set `FIRECRAWL_BASE_URL` and use it when calling the API:
+
+```ts
+const BASE_URL = process.env.FIRECRAWL_BASE_URL;
+const API_KEY = process.env.FIRECRAWL_API_KEY;
+
+async function scrapeUrl(url: string) {
+  const res = await fetch(`${BASE_URL}/api/scrape`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ url }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Firecrawl error ${res.status}`);
+  }
+
+  return await res.json();
+}
+```
 
 ## Example Enrichment
 

--- a/app/api/check-env/route.ts
+++ b/app/api/check-env/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 export async function GET() {
   const environmentStatus = {
     FIRECRAWL_API_KEY: !!process.env.FIRECRAWL_API_KEY,
+    FIRECRAWL_BASE_URL: !!process.env.FIRECRAWL_BASE_URL,
     OPENAI_API_KEY: !!process.env.OPENAI_API_KEY,
     ANTHROPIC_API_KEY: !!process.env.ANTHROPIC_API_KEY,
     FIRESTARTER_DISABLE_CREATION_DASHBOARD: process.env.FIRESTARTER_DISABLE_CREATION_DASHBOARD === 'true',


### PR DESCRIPTION
## Summary
- document FIRECRAWL_BASE_URL in `.env.example`
- explain custom Firecrawl setup and add fetch example in README
- expose FIRECRAWL_BASE_URL via `/api/check-env`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851a5c1053c832e945067b55c24144d